### PR TITLE
[feat]: Basic Unit Tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import { defineConfig } from "eslint/config";
 import tseslint, { parser } from "typescript-eslint";
 
 export default defineConfig({
+    ignores: ["**/*.test.ts"],
     extends: [
         js.configs.recommended,
         tseslint.configs.recommended,

--- a/library/src/behavior/built-in/ColorBehavior.ts
+++ b/library/src/behavior/built-in/ColorBehavior.ts
@@ -1,7 +1,7 @@
-import { Color, ColorSource } from "pixi.js";
 import { ColorList } from "../../data/list/ColorList";
 import { Emitter } from "../../Emitter";
 import { EmitterParticle } from "../../particle/EmitterParticle";
+import { convertHexToUint, convertUintToHex } from "../../util";
 import {
     BehaviorOrder,
     BehaviorSingleListConfig,
@@ -61,7 +61,7 @@ export class ColorBehavior
 {
     private readonly _list: ColorList;
 
-    private _staticValue: ColorSource = "#FFFFFF";
+    private _staticValue: number = 0xffffff;
     private _mode: "static" | "list" | "random" = "static";
 
     /**
@@ -110,11 +110,11 @@ export class ColorBehavior
     /**
      * Tint value applied to all particles in `static` mode.
      */
-    public get staticValue(): ColorSource {
-        return this._staticValue;
+    public get staticValue(): string {
+        return convertUintToHex(this._staticValue);
     }
-    public set staticValue(value: ColorSource) {
-        this._staticValue = value;
+    public set staticValue(value: string) {
+        this._staticValue = convertHexToUint(value);
     }
 
     /**
@@ -126,7 +126,7 @@ export class ColorBehavior
         this._emitter.addToActiveInitBehaviors(this);
 
         if ("value" in config) {
-            this._staticValue = config.value;
+            this._staticValue = convertHexToUint(config.value);
             this._mode = "static";
             this._list.reset();
 
@@ -154,7 +154,7 @@ export class ColorBehavior
 
         if (this._mode === "static") {
             return {
-                value: Color.shared.setValue(this._staticValue).toHex(),
+                value: convertUintToHex(this._staticValue),
                 mode: "static",
             };
         }
@@ -196,7 +196,7 @@ export class ColorBehavior
      * @inheritdoc
      */
     protected reset(): void {
-        this._staticValue = "#FFFFFF";
+        this._staticValue = 0xffffff;
         this._mode = "static";
 
         this._emitter.removeFromActiveInitBehaviors(this);

--- a/library/src/behavior/built-in/RotationBehavior.ts
+++ b/library/src/behavior/built-in/RotationBehavior.ts
@@ -86,7 +86,8 @@ export class RotationBehavior
 {
     private readonly _list: NumberList;
 
-    private _mode: "static" | "list" | "acceleration" | "direction" = "static";
+    private _mode: "static" | "list" | "random" | "acceleration" | "direction" =
+        "static";
 
     private _staticValue: number = 0;
     private _startRotation: number = 0;
@@ -122,7 +123,12 @@ export class RotationBehavior
     /**
      * Current mode used by the behavior.
      */
-    public get mode(): "static" | "list" | "acceleration" | "direction" {
+    public get mode():
+        | "static"
+        | "list"
+        | "random"
+        | "acceleration"
+        | "direction" {
         return this._mode;
     }
     public set mode(value: "static" | "list" | "acceleration" | "direction") {
@@ -189,8 +195,12 @@ export class RotationBehavior
             return;
         }
 
+        this._mode = config.mode;
         this._list.initialize(config.listData);
-        this._emitter.addToActiveUpdateBehaviors(this);
+
+        if (this._mode === "list") {
+            this._emitter.addToActiveUpdateBehaviors(this);
+        }
     }
 
     /**
@@ -215,9 +225,9 @@ export class RotationBehavior
             };
         }
 
-        if (this._mode === "list") {
+        if (this._mode === "list" || this._mode === "random") {
             return {
-                mode: "list",
+                mode: this._mode,
                 listData: {
                     list: this._list.list,
                     isStepped: this._list.isStepped ? true : undefined,
@@ -238,6 +248,11 @@ export class RotationBehavior
     public init(particle: EmitterParticle): void {
         if (this._mode === "list") {
             particle.rotation = this._list.interpolate(0);
+            return;
+        }
+
+        if (this._mode === "random") {
+            particle.rotation = this._list.interpolate(Math.random());
             return;
         }
 

--- a/library/src/data/list/NumberList.ts
+++ b/library/src/data/list/NumberList.ts
@@ -16,6 +16,9 @@ function simpleValue(this: List<number>, lerp: number): number {
 
     if (this.ease) lerp = this.ease(lerp);
 
+    if (lerp <= 0) return this.first.value;
+    if (lerp >= 1) return this.first.next.value;
+
     return (this.first.next.value - this.first.value) * lerp + this.first.value;
 }
 
@@ -37,19 +40,22 @@ function complexValue(this: List<number>, lerp: number): number {
         );
     }
 
-    let next = current.next;
+    if (lerp <= current.time) return current.value;
 
-    while (lerp > next.time) {
-        current = next;
-
-        // TODO: Handle error better?
-        next = next.next!;
+    while (current.next && lerp > current.next.time) {
+        current = current.next;
     }
 
-    // Convert the lerp value to the segment range.
-    lerp = (lerp - current.time) / (next.time - current.time);
+    if (!current.next) return current.value;
 
-    return (next.value - current.value) * lerp + current.value;
+    const next = current.next;
+    const denom = next.time - current.time;
+
+    if (denom === 0) return current.value;
+
+    // Convert the lerp value to the segment range.
+    const t = (lerp - current.time) / denom;
+    return (next.value - current.value) * t + current.value;
 }
 
 /**
@@ -69,7 +75,7 @@ function steppedValue(this: List<number>, lerp: number): number {
         );
     }
 
-    while (current.next && lerp > current.next.time) {
+    while (current.next && lerp >= current.next.time) {
         current = current.next;
     }
 

--- a/library/src/util/ColorUtil.ts
+++ b/library/src/util/ColorUtil.ts
@@ -47,3 +47,22 @@ export function convertHexToRGB(color: string, output?: RGBAColor): RGBAColor {
 
     return output;
 }
+
+/**
+ * Converts a uint color (0xRRGGBB) to a hex string ("#RRGGBB").
+ * @param color The color in the form of `0xRRGGBB`
+ * @returns The color as a hex string.
+ */
+export function convertUintToHex(color: number): string {
+    return `#${color.toString(16).padStart(6, "0")}`;
+}
+
+/**
+ * Converts a hex string ("#RRGGBB") to a uint color (0xRRGGBB).
+ * @param color The color as a hex string.
+ * @returns The color in the form of `0xRRGGBB`
+ */
+export function convertHexToUint(color: string): number {
+    const rgb = convertHexToRGB(color);
+    return convertRgbToUint(rgb.r, rgb.g, rgb.b);
+}

--- a/library/tests/behavior/built-in/AlphaBehavior.test.ts
+++ b/library/tests/behavior/built-in/AlphaBehavior.test.ts
@@ -1,0 +1,140 @@
+import { ParticleContainer } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { AlphaBehavior, Emitter } from "../../../src";
+
+vi.mock("pixi.js", () => {
+    class ParticleContainer {
+        constructor() {}
+    }
+
+    class Texture {
+        static EMPTY = new Texture("EMPTY");
+        static WHITE = new Texture("WHITE");
+
+        constructor(public readonly id: string = "TEX") {}
+    }
+
+    class Particle {
+        public texture: Texture;
+
+        public anchorX = 0;
+        public anchorY = 0;
+
+        public alpha = 1;
+
+        public scaleX = 1;
+        public scaleY = 1;
+
+        public rotation = 0;
+
+        constructor(texture: Texture) {
+            this.texture = texture;
+        }
+    }
+
+    return { ParticleContainer, Particle };
+});
+
+vi.mock("../../../src/Emitter", () => {
+    class Emitter {
+        private _initActive = false;
+        private _updateActive = false;
+
+        constructor() {}
+
+        public isBehaviorInitActive(): boolean {
+            return this._initActive;
+        }
+        public isBehaviorUpdateActive(): boolean {
+            return this._updateActive;
+        }
+
+        public addToActiveInitBehaviors(): void {
+            this._initActive = true;
+        }
+        public addToActiveUpdateBehaviors(): void {
+            this._updateActive = true;
+        }
+
+        public removeFromActiveInitBehaviors(): void {
+            this._initActive = false;
+        }
+        public removeFromActiveUpdateBehaviors(): void {
+            this._updateActive = false;
+        }
+    }
+
+    return { Emitter };
+});
+
+describe("AlphaBehavior config application/retrieving", () => {
+    const container = new ParticleContainer();
+    const emitter = new Emitter(container);
+
+    it("retrieves undefined by default", () => {
+        const behavior = new AlphaBehavior(emitter);
+        const config = behavior.getConfig();
+
+        expect(config).toBeUndefined();
+    });
+
+    it("applies and retrieves static config", () => {
+        const behavior = new AlphaBehavior(emitter);
+        behavior.applyConfig({ mode: "static", value: 0.5 });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({ mode: "static", value: 0.5 });
+    });
+
+    it("applies and retrieves list config", () => {
+        const behavior = new AlphaBehavior(emitter);
+        behavior.applyConfig({
+            mode: "list",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "list",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+    });
+
+    it("applies and retrieves random config", () => {
+        const behavior = new AlphaBehavior(emitter);
+        behavior.applyConfig({
+            mode: "random",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "random",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+    });
+});

--- a/library/tests/behavior/built-in/ColorBehavior.test.ts
+++ b/library/tests/behavior/built-in/ColorBehavior.test.ts
@@ -1,6 +1,6 @@
 import { ParticleContainer } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
-import { AlphaBehavior, Emitter } from "../../../src";
+import { ColorBehavior, Emitter } from "../../../src";
 
 vi.mock("pixi.js", () => {
     class ParticleContainer {
@@ -72,32 +72,32 @@ describe("AlphaBehavior config application/retrieving", () => {
     const emitter = new Emitter(container);
 
     it("retrieves undefined by default", () => {
-        const behavior = new AlphaBehavior(emitter);
+        const behavior = new ColorBehavior(emitter);
         const config = behavior.getConfig();
 
         expect(config).toBeUndefined();
     });
 
     it("applies and retrieves static config", () => {
-        const behavior = new AlphaBehavior(emitter);
-        behavior.applyConfig({ mode: "static", value: 0.5 });
+        const behavior = new ColorBehavior(emitter);
+        behavior.applyConfig({ mode: "static", value: "#ff00ff" });
 
         const config = behavior.getConfig();
-        expect(config).toEqual({ mode: "static", value: 0.5 });
+        expect(config).toEqual({ mode: "static", value: "#ff00ff" });
 
         expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
         expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
     });
 
     it("applies and retrieves list config", () => {
-        const behavior = new AlphaBehavior(emitter);
+        const behavior = new ColorBehavior(emitter);
         behavior.applyConfig({
             mode: "list",
             listData: {
                 list: [
-                    { time: 0, value: 0 },
-                    { time: 0.5, value: 1 },
-                    { time: 1, value: 0 },
+                    { time: 0, value: "#000000" },
+                    { time: 0.5, value: "#ffffff" },
+                    { time: 1, value: "#000000" },
                 ],
             },
         });
@@ -107,9 +107,9 @@ describe("AlphaBehavior config application/retrieving", () => {
             mode: "list",
             listData: {
                 list: [
-                    { time: 0, value: 0 },
-                    { time: 0.5, value: 1 },
-                    { time: 1, value: 0 },
+                    { time: 0, value: "#000000" },
+                    { time: 0.5, value: "#ffffff" },
+                    { time: 1, value: "#000000" },
                 ],
             },
         });
@@ -119,14 +119,14 @@ describe("AlphaBehavior config application/retrieving", () => {
     });
 
     it("applies and retrieves random config", () => {
-        const behavior = new AlphaBehavior(emitter);
+        const behavior = new ColorBehavior(emitter);
         behavior.applyConfig({
             mode: "random",
             listData: {
                 list: [
-                    { time: 0, value: 0 },
-                    { time: 0.5, value: 1 },
-                    { time: 1, value: 0 },
+                    { time: 0, value: "#000000" },
+                    { time: 0.5, value: "#ffffff" },
+                    { time: 1, value: "#000000" },
                 ],
             },
         });
@@ -136,9 +136,9 @@ describe("AlphaBehavior config application/retrieving", () => {
             mode: "random",
             listData: {
                 list: [
-                    { time: 0, value: 0 },
-                    { time: 0.5, value: 1 },
-                    { time: 1, value: 0 },
+                    { time: 0, value: "#000000" },
+                    { time: 0.5, value: "#ffffff" },
+                    { time: 1, value: "#000000" },
                 ],
             },
         });

--- a/library/tests/behavior/built-in/RotationBehavior.test.ts
+++ b/library/tests/behavior/built-in/RotationBehavior.test.ts
@@ -1,0 +1,179 @@
+import { ParticleContainer } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { Emitter, RotationBehavior } from "../../../src";
+
+vi.mock("pixi.js", () => {
+    class ParticleContainer {
+        constructor() {}
+    }
+
+    class Texture {
+        static EMPTY = new Texture("EMPTY");
+        static WHITE = new Texture("WHITE");
+
+        constructor(public readonly id: string = "TEX") {}
+    }
+
+    class Particle {
+        public texture: Texture;
+
+        public anchorX = 0;
+        public anchorY = 0;
+
+        public alpha = 1;
+
+        public scaleX = 1;
+        public scaleY = 1;
+
+        public rotation = 0;
+
+        constructor(texture: Texture) {
+            this.texture = texture;
+        }
+    }
+
+    return { ParticleContainer, Particle };
+});
+
+vi.mock("../../../src/Emitter", () => {
+    class Emitter {
+        private _initActive = false;
+        private _updateActive = false;
+
+        constructor() {}
+
+        public isBehaviorInitActive(): boolean {
+            return this._initActive;
+        }
+        public isBehaviorUpdateActive(): boolean {
+            return this._updateActive;
+        }
+
+        public addToActiveInitBehaviors(): void {
+            this._initActive = true;
+        }
+        public addToActiveUpdateBehaviors(): void {
+            this._updateActive = true;
+        }
+
+        public removeFromActiveInitBehaviors(): void {
+            this._initActive = false;
+        }
+        public removeFromActiveUpdateBehaviors(): void {
+            this._updateActive = false;
+        }
+    }
+
+    return { Emitter };
+});
+
+describe("AlphaBehavior config application/retrieving", () => {
+    const container = new ParticleContainer();
+    const emitter = new Emitter(container);
+
+    it("retrieves undefined by default", () => {
+        const behavior = new RotationBehavior(emitter);
+        const config = behavior.getConfig();
+
+        expect(config).toBeUndefined();
+    });
+
+    it("applies and retrieves static config", () => {
+        const behavior = new RotationBehavior(emitter);
+        behavior.applyConfig({ mode: "static", value: 0.5 });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({ mode: "static", value: 0.5 });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
+    });
+
+    it("applies and retrieves list config", () => {
+        const behavior = new RotationBehavior(emitter);
+        behavior.applyConfig({
+            mode: "list",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "list",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(true);
+    });
+
+    it("applies and retrieves random config", () => {
+        const behavior = new RotationBehavior(emitter);
+        behavior.applyConfig({
+            mode: "random",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "random",
+            listData: {
+                list: [
+                    { time: 0, value: 0 },
+                    { time: 0.5, value: 1 },
+                    { time: 1, value: 0 },
+                ],
+            },
+        });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
+    });
+
+    it("applies and retrieves direction config", () => {
+        const behavior = new RotationBehavior(emitter);
+        behavior.applyConfig({ mode: "direction" });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({ mode: "direction" });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
+    });
+
+    it("applies and retrieves acceleration config", () => {
+        const behavior = new RotationBehavior(emitter);
+        behavior.applyConfig({
+            mode: "acceleration",
+            startRotation: 0.5,
+            acceleration: 0.1,
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "acceleration",
+            startRotation: 0.5,
+            acceleration: 0.1,
+        });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(true);
+    });
+});

--- a/library/tests/behavior/built-in/ScaleBehavior.test.ts
+++ b/library/tests/behavior/built-in/ScaleBehavior.test.ts
@@ -1,0 +1,177 @@
+import { ParticleContainer } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { Emitter, ScaleBehavior } from "../../../src";
+
+vi.mock("pixi.js", () => {
+    class ParticleContainer {
+        constructor() {}
+    }
+
+    class Texture {
+        static EMPTY = new Texture("EMPTY");
+        static WHITE = new Texture("WHITE");
+
+        constructor(public readonly id: string = "TEX") {}
+    }
+
+    class Particle {
+        public texture: Texture;
+
+        public anchorX = 0;
+        public anchorY = 0;
+
+        public alpha = 1;
+
+        public scaleX = 1;
+        public scaleY = 1;
+
+        public rotation = 0;
+
+        constructor(texture: Texture) {
+            this.texture = texture;
+        }
+    }
+
+    return { ParticleContainer, Particle };
+});
+
+vi.mock("../../../src/Emitter", () => {
+    class Emitter {
+        private _initActive = false;
+        private _updateActive = false;
+
+        constructor() {}
+
+        public isBehaviorInitActive(): boolean {
+            return this._initActive;
+        }
+        public isBehaviorUpdateActive(): boolean {
+            return this._updateActive;
+        }
+
+        public addToActiveInitBehaviors(): void {
+            this._initActive = true;
+        }
+        public addToActiveUpdateBehaviors(): void {
+            this._updateActive = true;
+        }
+
+        public removeFromActiveInitBehaviors(): void {
+            this._initActive = false;
+        }
+        public removeFromActiveUpdateBehaviors(): void {
+            this._updateActive = false;
+        }
+    }
+
+    return { Emitter };
+});
+
+describe("AlphaBehavior config application/retrieving", () => {
+    const container = new ParticleContainer();
+    const emitter = new Emitter(container);
+
+    it("retrieves undefined by default", () => {
+        const behavior = new ScaleBehavior(emitter);
+        const config = behavior.getConfig();
+
+        expect(config).toBeUndefined();
+    });
+
+    it("applies and retrieves static config", () => {
+        const behavior = new ScaleBehavior(emitter);
+        behavior.applyConfig({ mode: "static", value: { x: 5, y: 5 } });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({ mode: "static", value: { x: 5, y: 5 } });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
+    });
+
+    it("applies and retrieves list config", () => {
+        const behavior = new ScaleBehavior(emitter);
+        behavior.applyConfig({
+            mode: "list",
+            xListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+            yListData: {
+                list: [
+                    { time: 0, value: 4 },
+                    { time: 0.5, value: 5 },
+                    { time: 1, value: 6 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "list",
+            xListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+            yListData: {
+                list: [
+                    { time: 0, value: 4 },
+                    { time: 0.5, value: 5 },
+                    { time: 1, value: 6 },
+                ],
+            },
+        });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(true);
+    });
+
+    it("applies and retrieves random config", () => {
+        const behavior = new ScaleBehavior(emitter);
+        behavior.applyConfig({
+            mode: "random",
+            xListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+            yListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+        });
+
+        const config = behavior.getConfig();
+        expect(config).toEqual({
+            mode: "random",
+            xListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+            yListData: {
+                list: [
+                    { time: 0, value: 1 },
+                    { time: 0.5, value: 2 },
+                    { time: 1, value: 3 },
+                ],
+            },
+        });
+
+        expect(emitter.isBehaviorInitActive(behavior)).toBe(true);
+        expect(emitter.isBehaviorUpdateActive(behavior)).toBe(false);
+    });
+});

--- a/library/tests/behavior/built-in/SpawnBehavior.test.ts
+++ b/library/tests/behavior/built-in/SpawnBehavior.test.ts
@@ -1,0 +1,125 @@
+import { ParticleContainer } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+    CircleConfig,
+    Emitter,
+    LineConfig,
+    PointConfig,
+    RectangleConfig,
+    SpawnBehavior,
+} from "../../../src";
+
+vi.mock("pixi.js", () => {
+    /**
+     * Mock ParticleContainer class
+     */
+    class ParticleContainer {
+        constructor() {}
+    }
+
+    /**
+     * Mock Texture class
+     */
+    class Texture {
+        static EMPTY = new Texture("EMPTY");
+        static WHITE = new Texture("WHITE");
+
+        /**
+         * Creates a new Texture.
+         * @param id Texture identifier.
+         */
+        constructor(public readonly id: string = "TEX") {}
+    }
+
+    /**
+     * Mock Particle class
+     */
+    class Particle {
+        public texture: Texture;
+
+        public anchorX = 0;
+        public anchorY = 0;
+
+        public alpha = 1;
+
+        public scaleX = 1;
+        public scaleY = 1;
+
+        public rotation = 0;
+
+        /**
+         * Creates a new Particle.
+         * @param texture The texture of the particle.
+         */
+        constructor(texture: Texture) {
+            this.texture = texture;
+        }
+    }
+
+    return { ParticleContainer, Particle };
+});
+
+vi.mock("../../../src/Emitter", () => {
+    /**
+     * Mock Emitter class
+     */
+    class Emitter {
+        constructor() {}
+    }
+
+    return { Emitter };
+});
+
+describe("SpawnBehavior config application/retrieving", () => {
+    const container = new ParticleContainer();
+    const emitter = new Emitter(container);
+
+    it("retrieves default config", () => {
+        const behavior = new SpawnBehavior(emitter);
+        const config = behavior.getConfig();
+
+        expect(config.shape).toBe("point");
+        expect(config.direction).toEqual({ x: 0, y: 0 });
+    });
+
+    it("applies and retrieves point config", () => {
+        const behavior = new SpawnBehavior(emitter);
+        behavior.applyConfig({ shape: "point" });
+
+        const config = behavior.getConfig() as PointConfig;
+        expect(config.shape).toBe("point");
+    });
+
+    it("applies and retrieves line config", () => {
+        const behavior = new SpawnBehavior(emitter);
+        behavior.applyConfig({ shape: "line", length: 100 });
+
+        const config = behavior.getConfig() as LineConfig;
+        expect(config.shape).toBe("line");
+        expect(config.length).toBe(100);
+    });
+
+    it("applies and retrieves rectangle config", () => {
+        const behavior = new SpawnBehavior(emitter);
+        behavior.applyConfig({ shape: "rectangle", width: 80, height: 40 });
+
+        const config = behavior.getConfig() as RectangleConfig;
+        expect(config.shape).toBe("rectangle");
+        expect(config.width).toBe(80);
+        expect(config.height).toBe(40);
+    });
+
+    it("applies and retrieves circle config", () => {
+        const behavior = new SpawnBehavior(emitter);
+        behavior.applyConfig({
+            shape: "circle",
+            outerRadius: 50,
+            innerRadius: 10,
+        });
+
+        const config = behavior.getConfig() as CircleConfig;
+        expect(config.shape).toBe("circle");
+        expect(config.outerRadius).toBe(50);
+        expect(config.innerRadius).toBe(10);
+    });
+});

--- a/library/tests/data/list/ColorList.test.ts
+++ b/library/tests/data/list/ColorList.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, test } from "vitest";
+import { ColorList, EmitterError, RGBAColor } from "../../../src";
+
+const hexToUint24 = (hex: string): number => {
+    const string = hex.trim().toLowerCase();
+    const normalized = string.startsWith("#") ? string.slice(1) : string;
+
+    return parseInt(normalized, 16) & 0xffffff;
+};
+
+test("Default interpolate function throws EmitterError", () => {
+    const list = new ColorList();
+
+    expect(() => list.interpolate(0)).toThrow(EmitterError);
+});
+
+describe("ColorList simple interpolation", () => {
+    const list = new ColorList();
+    list.initialize({
+        list: [
+            { time: 0, value: "#ff0000" },
+            { time: 1, value: "#0000ff" },
+        ],
+    });
+
+    it("should be #ff0000 at time 0", () => {
+        expect(list.interpolate(0)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should be #800080 at time 0.5", () => {
+        expect(list.interpolate(0.5)).toBe(hexToUint24("#800080"));
+    });
+
+    it("should be #0000ff at time 1", () => {
+        expect(list.interpolate(1)).toBe(hexToUint24("#0000ff"));
+    });
+});
+
+describe("ColorList stepped interpolation", () => {
+    const list = new ColorList();
+    list.initialize({
+        isStepped: true,
+        list: [
+            { time: 0, value: "#ff0000" },
+            { time: 0.5, value: "#00ff00" },
+            { time: 1, value: "#0000ff" },
+        ],
+    });
+
+    it("should be #ff0000 at time 0", () => {
+        expect(list.interpolate(0)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should be #ff0000 at time 0.3", () => {
+        expect(list.interpolate(0.3)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should be #00ff00 at time 0.5", () => {
+        expect(list.interpolate(0.5)).toBe(hexToUint24("#00ff00"));
+    });
+
+    it("should be #00ff00 at time 0.8", () => {
+        expect(list.interpolate(0.8)).toBe(hexToUint24("#00ff00"));
+    });
+
+    it("should be #0000ff at time 1", () => {
+        expect(list.interpolate(1)).toBe(hexToUint24("#0000ff"));
+    });
+});
+
+describe("ColorList complex interpolation", () => {
+    const list = new ColorList();
+    list.initialize({
+        list: [
+            { time: 0, value: "#ff0000" },
+            { time: 0.3, value: "#00ff00" },
+            { time: 0.7, value: "#0000ff" },
+            { time: 1, value: "#ffff00" },
+        ],
+    });
+
+    const lerp = (first: RGBAColor, second: RGBAColor, t: number): number => {
+        const r = Math.round((second.r - first.r) * t + first.r);
+        const g = Math.round((second.g - first.g) * t + first.g);
+        const b = Math.round((second.b - first.b) * t + first.b);
+
+        return ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff);
+    };
+
+    it("should be #ff0000 at time 0", () => {
+        expect(list.interpolate(0)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should interpolate within the bracketing segment at time 0.5", () => {
+        const u = (0.5 - 0.3) / (0.7 - 0.3);
+        const expected = lerp(
+            { r: 0, g: 255, b: 0, a: 255 },
+            { r: 0, g: 0, b: 255, a: 255 },
+            u,
+        );
+
+        expect(list.interpolate(0.5)).toBe(expected);
+    });
+
+    it("should interpolate within the bracketing segment at time 1", () => {
+        const u = (1 - 0.7) / (1 - 0.7);
+        const expected = lerp(
+            { r: 0, g: 0, b: 255, a: 255 },
+            { r: 255, g: 255, b: 0, a: 255 },
+            u,
+        );
+
+        expect(list.interpolate(1)).toBe(expected);
+    });
+});
+
+describe("ColorList boundary conditions", () => {
+    const list = new ColorList();
+    list.initialize({
+        list: [
+            { time: 0.2, value: "#ff0000" },
+            { time: 0.8, value: "#0000ff" },
+        ],
+    });
+
+    it("should return the first color for lerp < first time", () => {
+        expect(list.interpolate(0)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should return the last color for lerp > last time", () => {
+        expect(list.interpolate(1)).toBe(hexToUint24("#0000ff"));
+    });
+
+    it("should return the first color for lerp == first time", () => {
+        expect(list.interpolate(0.2)).toBe(hexToUint24("#ff0000"));
+    });
+
+    it("should return the last color for lerp == last time", () => {
+        expect(list.interpolate(0.8)).toBe(hexToUint24("#0000ff"));
+    });
+});

--- a/library/tests/data/list/NumberList.test.ts
+++ b/library/tests/data/list/NumberList.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import { EmitterError, NumberList } from "../../../src";
+
+test("Default interpolate function throws EmitterError", () => {
+    const list = new NumberList();
+
+    expect(() => list.interpolate(0)).toThrow(EmitterError);
+});

--- a/library/tests/data/list/NumberList.test.ts
+++ b/library/tests/data/list/NumberList.test.ts
@@ -1,8 +1,125 @@
-import { expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import { EmitterError, NumberList } from "../../../src";
 
 test("Default interpolate function throws EmitterError", () => {
     const list = new NumberList();
 
     expect(() => list.interpolate(0)).toThrow(EmitterError);
+});
+
+describe("NumberList simple interpolation", () => {
+    const list = new NumberList();
+    list.initialize({
+        list: [
+            { time: 0, value: 10 },
+            { time: 1, value: 20 },
+        ],
+    });
+
+    it("should be 10 at time 0", () => {
+        expect(list.interpolate(0)).toBe(10);
+    });
+
+    it("should be 15 at time 0.5", () => {
+        expect(list.interpolate(0.5)).toBe(15);
+    });
+
+    it("should be 20 at time 1", () => {
+        expect(list.interpolate(1)).toBe(20);
+    });
+});
+
+describe("NumberList stepped interpolation", () => {
+    const list = new NumberList();
+    list.initialize({
+        isStepped: true,
+        list: [
+            { time: 0, value: 10 },
+            { time: 0.5, value: 20 },
+            { time: 1, value: 30 },
+        ],
+    });
+
+    it("should be 10 at time 0", () => {
+        expect(list.interpolate(0)).toBe(10);
+    });
+
+    it("should be 10 at time 0.3", () => {
+        expect(list.interpolate(0.3)).toBe(10);
+    });
+
+    it("should be 20 at time 0.5", () => {
+        expect(list.interpolate(0.5)).toBe(20);
+    });
+
+    it("should be 20 at time 0.8", () => {
+        expect(list.interpolate(0.8)).toBe(20);
+    });
+
+    it("should be 30 at time 1", () => {
+        expect(list.interpolate(1)).toBe(30);
+    });
+});
+
+describe("NumberList complex interpolation", () => {
+    const list = new NumberList();
+    list.initialize({
+        list: [
+            { time: 0, value: 10 },
+            { time: 0.3, value: 20 },
+            { time: 0.7, value: 15 },
+            { time: 1, value: 25 },
+        ],
+    });
+
+    const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+    it("should interpolate within the bracketing segment at time 0", () => {
+        const u = (0 - 0) / (0.3 - 0);
+        const expected = lerp(10, 20, u);
+
+        expect(list.interpolate(u)).toBeCloseTo(expected, 1);
+    });
+
+    it("should interpolate within the bracketing segment at time 0.5", () => {
+        const u = (0.5 - 0.3) / (0.7 - 0.3);
+        const expected = lerp(20, 15, u);
+
+        expect(list.interpolate(0.5)).toBeCloseTo(expected, 1);
+    });
+
+    it("should interpolate within the bracketing segment at time 1", () => {
+        const u = (1 - 0.7) / (1 - 0.7);
+        const expected = lerp(15, 25, u);
+
+        expect(list.interpolate(1)).toBeCloseTo(expected, 1);
+    });
+});
+
+describe("NumberList boundary conditions", () => {
+    const list = new NumberList();
+    list.initialize({
+        list: [
+            { time: 0.2, value: 10 },
+            { time: 0.8, value: 20 },
+        ],
+    });
+
+    it("should return the first value for lerp < first time", () => {
+        expect(list.interpolate(0)).toBe(10);
+        expect(list.interpolate(0.1)).toBe(10);
+    });
+
+    it("should return the last value for lerp > last time", () => {
+        expect(list.interpolate(0.9)).toBe(20);
+        expect(list.interpolate(1)).toBe(20);
+    });
+
+    it("should return the first value for lerp == first time", () => {
+        expect(list.interpolate(0.2)).toBe(10);
+    });
+
+    it("should return the last value for lerp == last time", () => {
+        expect(list.interpolate(0.8)).toBe(20);
+    });
 });

--- a/library/tests/error/EmitterError.test.ts
+++ b/library/tests/error/EmitterError.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { EmitterError } from "../../src/error/EmitterError";
+
+describe("EmitterError", () => {
+    it("should be an Error and set name to EmitterError", () => {
+        const err = new EmitterError("boom");
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(EmitterError);
+        expect(err.name).toBe("EmitterError");
+    });
+
+    it("should prefix the message with 'EmitterError: '", () => {
+        const err = new EmitterError("something went wrong");
+        expect(err.message).toBe("EmitterError: something went wrong");
+    });
+
+    it("should work with an empty message", () => {
+        const err = new EmitterError("");
+        expect(err.message).toBe("EmitterError: ");
+        expect(err.name).toBe("EmitterError");
+    });
+});

--- a/library/tests/particle/EmitterParticle.test.ts
+++ b/library/tests/particle/EmitterParticle.test.ts
@@ -1,0 +1,183 @@
+import { Texture } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { EmitterParticle } from "../../src";
+
+vi.mock("pixi.js", () => {
+    /**
+     * Mock Texture class
+     */
+    class Texture {
+        static EMPTY = new Texture("EMPTY");
+        static WHITE = new Texture("WHITE");
+
+        /**
+         * Creates a new Texture.
+         * @param id Texture identifier.
+         */
+        constructor(public readonly id: string = "TEX") {}
+    }
+
+    /**
+     * Mock Particle class
+     */
+    class Particle {
+        public texture: Texture;
+
+        public anchorX = 0;
+        public anchorY = 0;
+
+        public alpha = 1;
+
+        public scaleX = 1;
+        public scaleY = 1;
+
+        public rotation = 0;
+
+        /**
+         * Creates a new Particle.
+         * @param texture The texture of the particle.
+         */
+        constructor(texture: Texture) {
+            this.texture = texture;
+        }
+    }
+
+    return { Texture, Particle };
+});
+
+describe("EmitterParticle", () => {
+    it("initializes defaults via reset()", async () => {
+        const p = new EmitterParticle();
+
+        expect(p.texture).toBe(Texture.EMPTY);
+
+        expect(p.anchorX).toBe(0.5);
+        expect(p.anchorY).toBe(0.5);
+
+        expect(p.alpha).toBe(1);
+
+        expect(p.scaleX).toBe(1);
+        expect(p.scaleY).toBe(1);
+
+        expect(p.rotation).toBe(0);
+
+        expect(p.data.age).toBe(0);
+        expect(p.data.agePercent).toBe(0);
+        expect(p.data.maxLifetime).toBe(0);
+        expect(p.data.oneOverLifetime).toBe(0);
+
+        expect(p.data.directionVectorX).toBe(0);
+        expect(p.data.directionVectorY).toBe(0);
+
+        expect(p.data.accelerationX).toBe(0);
+        expect(p.data.accelerationY).toBe(0);
+
+        expect(p.data.velocityX).toBe(0);
+        expect(p.data.velocityY).toBe(0);
+
+        expect(Array.isArray(p.data.textureConfig.textures)).toBe(true);
+        expect(p.data.textureConfig.textures).toHaveLength(0);
+        expect(p.data.textureConfig.duration).toBe(0);
+        expect(p.data.textureConfig.elapsed).toBe(0);
+        expect(p.data.textureConfig.framerate).toBe(0);
+        expect(p.data.textureConfig.loop).toBe(false);
+    });
+
+    it("reset() restores defaults after mutation", async () => {
+        const p = new EmitterParticle();
+
+        p.texture = Texture.WHITE;
+
+        p.anchorX = 0;
+        p.anchorY = 0;
+
+        p.alpha = 0.25;
+
+        p.scaleX = 2;
+        p.scaleY = 3;
+
+        p.rotation = 1.23;
+
+        p.data.age = 10;
+        p.data.agePercent = 0.5;
+        p.data.maxLifetime = 100;
+        p.data.oneOverLifetime = 0.01;
+
+        p.data.directionVectorX = 9;
+        p.data.directionVectorY = 8;
+
+        p.data.accelerationX = 7;
+        p.data.accelerationY = 6;
+
+        p.data.velocityX = 5;
+        p.data.velocityY = 4;
+
+        p.data.textureConfig.textures = [Texture.WHITE, Texture.WHITE];
+        p.data.textureConfig.duration = 1000;
+        p.data.textureConfig.elapsed = 500;
+        p.data.textureConfig.framerate = 60;
+        p.data.textureConfig.loop = true;
+
+        p.reset();
+
+        expect(p.texture).toBe(Texture.EMPTY);
+
+        expect(p.anchorX).toBe(0.5);
+        expect(p.anchorY).toBe(0.5);
+
+        expect(p.alpha).toBe(1);
+
+        expect(p.scaleX).toBe(1);
+        expect(p.scaleY).toBe(1);
+
+        expect(p.rotation).toBe(0);
+
+        expect(p.data.age).toBe(0);
+        expect(p.data.agePercent).toBe(0);
+        expect(p.data.maxLifetime).toBe(0);
+        expect(p.data.oneOverLifetime).toBe(0);
+
+        expect(p.data.directionVectorX).toBe(0);
+        expect(p.data.directionVectorY).toBe(0);
+
+        expect(p.data.accelerationX).toBe(0);
+        expect(p.data.accelerationY).toBe(0);
+
+        expect(p.data.velocityX).toBe(0);
+        expect(p.data.velocityY).toBe(0);
+
+        expect(p.data.textureConfig.textures).toHaveLength(0);
+        expect(p.data.textureConfig.duration).toBe(0);
+        expect(p.data.textureConfig.elapsed).toBe(0);
+        expect(p.data.textureConfig.framerate).toBe(0);
+        expect(p.data.textureConfig.loop).toBe(false);
+    });
+
+    it("reset() does not replace the data or textureConfig objects (mutates in place)", async () => {
+        const p = new EmitterParticle();
+
+        const dataRef = p.data;
+        const textureConfigRef = p.data.textureConfig;
+
+        p.data.age = 123;
+        p.data.textureConfig.loop = true;
+
+        p.reset();
+
+        expect(p.data).toBe(dataRef);
+        expect(p.data.textureConfig).toBe(textureConfigRef);
+
+        expect(p.data.age).toBe(0);
+        expect(p.data.textureConfig.loop).toBe(false);
+    });
+
+    it("reset() always creates an empty textures array", async () => {
+        const p = new EmitterParticle();
+
+        p.data.textureConfig.textures.push(Texture.WHITE);
+        expect(p.data.textureConfig.textures.length).toBe(1);
+
+        p.reset();
+        expect(p.data.textureConfig.textures).toEqual([]);
+    });
+});

--- a/library/tests/particle/EmitterParticle.test.ts
+++ b/library/tests/particle/EmitterParticle.test.ts
@@ -3,23 +3,13 @@ import { describe, expect, it, vi } from "vitest";
 import { EmitterParticle } from "../../src";
 
 vi.mock("pixi.js", () => {
-    /**
-     * Mock Texture class
-     */
     class Texture {
         static EMPTY = new Texture("EMPTY");
         static WHITE = new Texture("WHITE");
 
-        /**
-         * Creates a new Texture.
-         * @param id Texture identifier.
-         */
         constructor(public readonly id: string = "TEX") {}
     }
 
-    /**
-     * Mock Particle class
-     */
     class Particle {
         public texture: Texture;
 
@@ -33,10 +23,6 @@ vi.mock("pixi.js", () => {
 
         public rotation = 0;
 
-        /**
-         * Creates a new Particle.
-         * @param texture The texture of the particle.
-         */
         constructor(texture: Texture) {
             this.texture = texture;
         }

--- a/library/tests/util/ColorUtil.test.ts
+++ b/library/tests/util/ColorUtil.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { convertHexToRGB, convertRgbToUint } from "../../src";
+
+describe("convert RGB to Uint values", () => {
+    it("should be 0xff0000 for red", () => {
+        expect(convertRgbToUint(255, 0, 0)).toBe(0xff0000);
+    });
+
+    it("should be 0x00ff00 for green", () => {
+        expect(convertRgbToUint(0, 255, 0)).toBe(0x00ff00);
+    });
+
+    it("should be 0x0000ff for blue", () => {
+        expect(convertRgbToUint(0, 0, 255)).toBe(0x0000ff);
+    });
+
+    it("should be 0xffffff for white", () => {
+        expect(convertRgbToUint(255, 255, 255)).toBe(0xffffff);
+    });
+
+    it("should be 0x000000 for black", () => {
+        expect(convertRgbToUint(0, 0, 0)).toBe(0x000000);
+    });
+
+    it("should be 0x123456 for rgb(18, 52, 86)", () => {
+        expect(convertRgbToUint(18, 52, 86)).toBe(0x123456);
+    });
+
+    const r = Math.floor(Math.random() * 256);
+    const g = Math.floor(Math.random() * 256);
+    const b = Math.floor(Math.random() * 256);
+    const uintColor = (r << 16) | (g << 8) | b;
+
+    it(`should be ${uintColor.toString(16)} for rgb(${r}, ${g}, ${b})`, () => {
+        expect(convertRgbToUint(r, g, b)).toBe(uintColor);
+    });
+});
+
+describe("convert Hex to RGB values", () => {
+    it("should convert #ff0000 to (255, 0, 0)", () => {
+        expect(convertHexToRGB("#ff0000")).toEqual({ r: 255, g: 0, b: 0 });
+    });
+
+    it("should convert 0x00ff00 to (0, 255, 0)", () => {
+        expect(convertHexToRGB("0x00ff00")).toEqual({ r: 0, g: 255, b: 0 });
+    });
+
+    it("should convert 0x0000ff to (0, 0, 255)", () => {
+        expect(convertHexToRGB("0000ff")).toEqual({ r: 0, g: 0, b: 255 });
+    });
+
+    it("should convert 0xffffff to (255, 255, 255)", () => {
+        expect(convertHexToRGB("#ffffff")).toEqual({ r: 255, g: 255, b: 255 });
+    });
+
+    it("should convert 0x000000 to (0, 0, 0)", () => {
+        expect(convertHexToRGB("#000000")).toEqual({ r: 0, g: 0, b: 0 });
+    });
+
+    it("should convert 0x123456 to (18, 52, 86)", () => {
+        expect(convertHexToRGB("#123456")).toEqual({ r: 18, g: 52, b: 86 });
+    });
+
+    const color = Math.floor(Math.random() * 0xffffff);
+    const hexColor = `#${color.toString(16).padStart(6, "0")}`;
+    const r = (color >> 16) & 0xff;
+    const g = (color >> 8) & 0xff;
+    const b = color & 0xff;
+
+    it(`should convert ${hexColor} to (${r}, ${g}, ${b})`, () => {
+        expect(convertHexToRGB(hexColor)).toEqual({ r, g, b });
+    });
+});

--- a/library/tests/util/ColorUtil.test.ts
+++ b/library/tests/util/ColorUtil.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { convertHexToRGB, convertRgbToUint } from "../../src";
+import {
+    convertHexToRGB,
+    convertHexToUint,
+    convertRgbToUint,
+    convertUintToHex,
+} from "../../src";
 
 describe("convert RGB to Uint values", () => {
     it("should be 0xff0000 for red", () => {
@@ -69,5 +74,71 @@ describe("convert Hex to RGB values", () => {
 
     it(`should convert ${hexColor} to (${r}, ${g}, ${b})`, () => {
         expect(convertHexToRGB(hexColor)).toEqual({ r, g, b });
+    });
+});
+
+describe("convert Uint to Hex values", () => {
+    it("should convert 0xff0000 to #ff0000", () => {
+        expect(convertUintToHex(0xff0000)).toBe("#ff0000");
+    });
+
+    it("should convert 0x00ff00 to #00ff00", () => {
+        expect(convertUintToHex(0x00ff00)).toBe("#00ff00");
+    });
+
+    it("should convert 0x0000ff to #0000ff", () => {
+        expect(convertUintToHex(0x0000ff)).toBe("#0000ff");
+    });
+
+    it("should convert 0xffffff to #ffffff", () => {
+        expect(convertUintToHex(0xffffff)).toBe("#ffffff");
+    });
+
+    it("should convert 0x000000 to #000000", () => {
+        expect(convertUintToHex(0x000000)).toBe("#000000");
+    });
+
+    it("should convert 0x123456 to #123456", () => {
+        expect(convertUintToHex(0x123456)).toBe("#123456");
+    });
+
+    const color = Math.floor(Math.random() * 0xffffff);
+    const hexColor = `#${color.toString(16).padStart(6, "0")}`;
+
+    it(`should convert ${color.toString(16)} to ${hexColor}`, () => {
+        expect(convertUintToHex(color)).toBe(hexColor);
+    });
+});
+
+describe("convert Hex to Uint values", () => {
+    it("should convert #ff0000 to 0xff0000", () => {
+        expect(convertHexToUint("#ff0000")).toBe(0xff0000);
+    });
+
+    it("should convert 0x00ff00 to 0x00ff00", () => {
+        expect(convertHexToUint("0x00ff00")).toBe(0x00ff00);
+    });
+
+    it("should convert 0000ff to 0x0000ff", () => {
+        expect(convertHexToUint("0000ff")).toBe(0x0000ff);
+    });
+
+    it("should convert #ffffff to 0xffffff", () => {
+        expect(convertHexToUint("#ffffff")).toBe(0xffffff);
+    });
+
+    it("should convert #000000 to 0x000000", () => {
+        expect(convertHexToUint("#000000")).toBe(0x000000);
+    });
+
+    it("should convert #123456 to 0x123456", () => {
+        expect(convertHexToUint("#123456")).toBe(0x123456);
+    });
+
+    const color = Math.floor(Math.random() * 0xffffff);
+    const hexColor = `#${color.toString(16).padStart(6, "0")}`;
+
+    it(`should convert ${hexColor} to ${color.toString(16)}`, () => {
+        expect(convertHexToUint(hexColor)).toBe(color);
     });
 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "prettier": "^3.6.2",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.49.0",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^4.0.16"
     },
     "scripts": {
         "installDep": "pnpm install && cd library && pnpm install && cd ../editor && pnpm install",
@@ -18,7 +19,8 @@
         "dev:editor": "cd editor && pnpm dev",
         "build:library": "cd library && pnpm build:lib",
         "build:editor": "cd editor && pnpm build",
-        "build:docs": "cd library && pnpm build:docs"
+        "build:docs": "cd library && pnpm build:docs",
+        "test": "vitest"
     },
     "dependencies": {
         "@picocss/pico": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       vite:
         specifier: ^5.4.11
         version: 5.4.21
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16
 
 packages:
 
@@ -56,9 +59,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -68,9 +83,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -80,9 +107,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -92,9 +131,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -104,9 +155,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -116,9 +179,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -128,9 +203,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -140,9 +227,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -152,11 +251,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -164,9 +287,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -176,15 +317,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -241,6 +400,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@picocss/pico@2.1.1':
     resolution: {integrity: sha512-kIDugA7Ps4U+2BHxiNHmvgPIQDWPDU4IeU6TNRdvXQM1uZX+FibqDQT2xUOnnO2yq/LUHcwnGlu1hvf4KfXnMg==}
@@ -362,8 +524,17 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/css-font-loading-module@0.0.12':
     resolution: {integrity: sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/earcut@3.0.0':
     resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
@@ -433,6 +604,35 @@ packages:
     resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.0.16':
+    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+
+  '@vitest/mocker@4.0.16':
+    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.16':
+    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+
+  '@vitest/runner@4.0.16':
+    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+
+  '@vitest/snapshot@4.0.16':
+    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+
+  '@vitest/spy@4.0.16':
+    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+
+  '@vitest/utils@4.0.16':
+    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+
   '@webgpu/types@0.1.67':
     resolution: {integrity: sha512-uk53+2ECGUkWoDFez/hymwpRfdgdIn6y1ref70fEecGMe5607f4sozNFgBk0oxlr7j2CRGWBEc3IBYMmFdGGTQ==}
 
@@ -464,6 +664,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -476,6 +680,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -514,9 +722,17 @@ packages:
   earcut@3.0.2:
     resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-string-regexp@4.0.0:
@@ -567,12 +783,19 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -694,6 +917,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -714,6 +940,9 @@ packages:
 
   object-deep-merge@2.0.0:
     resolution: {integrity: sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -747,6 +976,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -801,6 +1033,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -813,6 +1048,12 @@ packages:
 
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -829,9 +1070,20 @@ packages:
     resolution: {integrity: sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==}
     engines: {node: '>=12'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   to-valid-identifier@1.0.0:
     resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
@@ -893,9 +1145,88 @@ packages:
       terser:
         optional: true
 
+  vite@7.3.0:
+    resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.16:
+    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.16
+      '@vitest/browser-preview': 4.0.16
+      '@vitest/browser-webdriverio': 4.0.16
+      '@vitest/ui': 4.0.16
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -921,70 +1252,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
@@ -1043,6 +1452,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@picocss/pico@2.1.1': {}
 
@@ -1116,7 +1527,16 @@ snapshots:
 
   '@sindresorhus/base62@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/css-font-loading-module@0.0.12': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/earcut@3.0.0': {}
 
@@ -1215,6 +1635,45 @@ snapshots:
       '@typescript-eslint/types': 8.49.0
       eslint-visitor-keys: 4.2.1
 
+  '@vitest/expect@4.0.16':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.16(vite@7.3.0)':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.0
+
+  '@vitest/pretty-format@4.0.16':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.16':
+    dependencies:
+      '@vitest/utils': 4.0.16
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.16': {}
+
+  '@vitest/utils@4.0.16':
+    dependencies:
+      '@vitest/pretty-format': 4.0.16
+      tinyrainbow: 3.0.3
+
   '@webgpu/types@0.1.67': {}
 
   '@xmldom/xmldom@0.8.11': {}
@@ -1240,6 +1699,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   brace-expansion@1.1.12:
@@ -1252,6 +1713,8 @@ snapshots:
       balanced-match: 1.0.2
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -1282,6 +1745,8 @@ snapshots:
 
   earcut@3.0.2: {}
 
+  es-module-lexer@1.7.0: {}
+
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -1307,6 +1772,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
 
   escape-string-regexp@4.0.0: {}
 
@@ -1394,9 +1888,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -1491,6 +1991,10 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -1506,6 +2010,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   object-deep-merge@2.0.0: {}
+
+  obug@2.1.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -1539,6 +2045,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -1610,6 +2118,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   spdx-exceptions@2.5.0: {}
@@ -1621,6 +2131,10 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
@@ -1631,10 +2145,16 @@ snapshots:
 
   tiny-lru@11.4.5: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-valid-identifier@1.0.0:
     dependencies:
@@ -1674,9 +2194,60 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  vite@7.3.0:
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.0.16:
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(vite@7.3.0)
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
# [feat]: Basic Unit Tests

## Summary

Adds basic unit tests to the particle system using Vitest platform. Currently the tests cover basic functionality, such as asserting the behaviour configs are set and retrieved correctly, but as the library becomes more stable, new tests will be introduced in future.

Additionally, fixes have been introduced as a result of the unit tests:
- **ColorBehavior**: Removed the dependency on `Color.shared` static, instead added helper functions to convert colours within the library - this minimises outside dependency, and makes it easier to unit test the behaviour. As a result, colours store in the behaviour (and lists) are represented as integer values, and are converted to hex strings when presented to users.
- **RotationBehavior**: Added missing `random` mode, and fixed other modes not being applied correctly.
- **Lists**: Fixes edge case scenarios related to boundary unit tests (0.1 is used to interpolate but first step has a time value of 0.3, etc.)